### PR TITLE
fix: ensure the volumes are properly mounted at boot time

### DIFF
--- a/files/attach-ebs-volume.service
+++ b/files/attach-ebs-volume.service
@@ -8,4 +8,4 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/sbin/attach_volume.sh
 [Install]
-WantedBy=multiuser.target
+WantedBy=multi-user.target

--- a/files/format-ebs-volume.service
+++ b/files/format-ebs-volume.service
@@ -8,4 +8,4 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/sbin/format_volume.sh
 [Install]
-WantedBy=multiuser.target
+WantedBy=multi-user.target

--- a/files/var-lib-etcd.mount
+++ b/files/var-lib-etcd.mount
@@ -7,4 +7,4 @@ What=/dev/xvdd
 Where=/var/lib/etcd
 Type=xfs
 [Install]
-WantedBy=multiuser.target
+WantedBy=multi-user.target

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class etcd_mount
     provider => 'systemd',
   }
 
-  file { '/etc/systemd/system/multiuser.target.wants/var-lib-etcd.mount':
+  file { '/etc/systemd/system/multi-user.target.wants/var-lib-etcd.mount':
     ensure => link,
     target => '/usr/lib/systemd/system/var-lib-etcd.mount',
   }


### PR DESCRIPTION
ETCD instance are currently not mounting the EBS volume after a restart. Missing dash :-) 